### PR TITLE
pinned Sphinx version for compatibility with Awesome theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx < 7.2
 sphinx-rtd-theme
-sphinxawesome-theme==5.0.0b1
+sphinxawesome-theme == 5.0.0b3


### PR DESCRIPTION
I had trouble generating html for the UnoAPI book. It turns out that Sphinx 7.2.6 gets installed, which doesn't seem to work with the sphinxawesome 5.0.0b1-3 prereleases. After reproducing the problem on my Ubuntu VM and trying a few other things, I came across this fix by chance:

```pip install sphinx==7.1.2```

So we might have to pin the Sphinx version to ensure it works. This might have arisen more recently than the most recent CI run in June.